### PR TITLE
Windows compatibility changes

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//+build !windows
+
 package logging
 
 import "log/syslog"


### PR DESCRIPTION
Since syslog is not available on Windows, I have added a build constraint so that syslog.go is not built on Windows.
