### PR TITLE
Added NewSyslogBackendPriority method

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -23,6 +23,14 @@ func NewSyslogBackend(prefix string) (b *SyslogBackend, err error) {
 	return &SyslogBackend{w}, err
 }
 
+// NewSyslogBackendPriority is the same as NewSyslogBackend, but with custom
+// syslog priority, like syslog.LOG_LOCAL3|syslog.LOG_DEBUG etc.
+func NewSyslogBackendPriority(prefix string, priority syslog.Priority) (b *SyslogBackend, err error) {
+	var w *syslog.Writer
+	w, err = syslog.New(priority, prefix)
+	return &SyslogBackend{w}, err
+}
+
 func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
 	switch level {
 	case CRITICAL:


### PR DESCRIPTION
Here is a proposition on how to add possibility to specify Syslog Priority, without breaking compatibility.
