### PR TITLE
Add Errorf, Warningf, Noticef, Infof, Debugf functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ func main() {
 		log.Warning("warning")
 		log.Notice("notice")
 		log.Info("info")
-		log.Debug("debug %s", Password("secret"))
+		log.Debugf("debug %s", Password("secret"))
 	}
 }
 ```

--- a/logger.go
+++ b/logger.go
@@ -185,8 +185,18 @@ func (l *Logger) Error(format string, args ...interface{}) {
 	l.log(ERROR, format, args...)
 }
 
+// Errorf logs a message using ERROR as log level.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.log(ERROR, format, args...)
+}
+
 // Warning logs a message using WARNING as log level.
 func (l *Logger) Warning(format string, args ...interface{}) {
+	l.log(WARNING, format, args...)
+}
+
+// Warningf logs a message using WARNING as log level.
+func (l *Logger) Warningf(format string, args ...interface{}) {
 	l.log(WARNING, format, args...)
 }
 
@@ -195,13 +205,28 @@ func (l *Logger) Notice(format string, args ...interface{}) {
 	l.log(NOTICE, format, args...)
 }
 
+// Noticef logs a message using NOTICE as log level.
+func (l *Logger) Noticef(format string, args ...interface{}) {
+	l.log(NOTICE, format, args...)
+}
+
 // Info logs a message using INFO as log level.
 func (l *Logger) Info(format string, args ...interface{}) {
 	l.log(INFO, format, args...)
 }
 
+// Infof logs a message using INFO as log level.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.log(INFO, format, args...)
+}
+
 // Debug logs a message using DEBUG as log level.
 func (l *Logger) Debug(format string, args ...interface{}) {
+	l.log(DEBUG, format, args...)
+}
+
+// Debugf logs a message using DEBUG as log level.
+func (l *Logger) Debugf(format string, args ...interface{}) {
 	l.log(DEBUG, format, args...)
 }
 


### PR DESCRIPTION
Added Errorf, Warningf, Noticef, Infof, Debugf to follow the tradition of functions taking formatters named with an f suffix. go vet is enforcing these for a good reason.

Please add these to the mainline codebase!