### PR TITLE
Fix the default time format

### DIFF
--- a/format.go
+++ b/format.go
@@ -47,7 +47,7 @@ var fmtVerbs = []string{
 }
 
 var defaultVerbsLayout = []string{
-	"2006-01-02T15:04:05.999Z-07:00",
+	"2006-01-02T15:04:05.999Z07:00",
 	"s",
 	"d",
 	"s",


### PR DESCRIPTION
The default time format is wrong, currently its listed as `2006-01-02T15:04:05.999Z-07:00`, however timezone should not be listed as `Z-07:00` but should be `Z07:00`. In the godocs for RFC3339Nano (http://golang.org/pkg/time/) is defined as `2006-01-02T15:04:05.999999999Z07:00` (with no `-` sign).

The problems this causes is a time will end up being formatted as `2014-06-27T16:55:32.325Z-07:00`, with both a `Z` and `-07:00`. For example on a machine with the timezone set to utc:

Current Output:

```
[2014-06-28T01:01:30.849Z+00:00] [test] [CRITICAL] crit [bad.go:39]
[2014-06-28T01:01:30.85Z+00:00] [test] [ERROR] err [bad.go:40]
[2014-06-28T01:01:30.85Z+00:00] [test] [WARNING] warning [bad.go:41]
[2014-06-28T01:01:30.853Z+00:00] [test] [NOTICE] notice [bad.go:42]
[2014-06-28T01:01:30.853Z+00:00] [test] [INFO] info [bad.go:43]
[2014-06-28T01:01:30.853Z+00:00] [test] [DEBUG] debug ****** [bad.go:44]
[2014-06-28T01:01:30.853Z+00:00] [test] [CRITICAL] crit [bad.go:39]
[2014-06-28T01:01:30.853Z+00:00] [test] [ERROR] err [bad.go:40]
```

Correct Output:

```
[2014-06-28T01:00:47.093Z] [test] [CRITICAL] crit [a.go:39]
[2014-06-28T01:00:47.093Z] [test] [ERROR] err [a.go:40]
[2014-06-28T01:00:47.094Z] [test] [WARNING] warning [a.go:41]
[2014-06-28T01:00:47.096Z] [test] [NOTICE] notice [a.go:42]
[2014-06-28T01:00:47.096Z] [test] [INFO] info [a.go:43]
[2014-06-28T01:00:47.097Z] [test] [DEBUG] debug ****** [a.go:44]
[2014-06-28T01:00:47.097Z] [test] [CRITICAL] crit [a.go:39]
[2014-06-28T01:00:47.097Z] [test] [ERROR] err [a.go:40]
```

Because both the Z and timezone is listed, other applications, such as logstash, fail to parse these times as valid RFC3339 time.

The PR fixes this mistake.
