### PR TITLE
Allow to setup default calldepth

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -82,6 +82,7 @@ type Logger struct {
 	Module      string
 	backend     LeveledBackend
 	haveBackend bool
+	calldepth   int
 }
 
 func (l *Logger) SetBackend(backend LeveledBackend) {
@@ -89,10 +90,14 @@ func (l *Logger) SetBackend(backend LeveledBackend) {
 	l.haveBackend = true
 }
 
+func (l *Logger) SetCalldepth(calldepth int) {
+	l.calldepth = calldepth
+}
+
 // TODO call NewLogger and remove MustGetLogger?
 // GetLogger creates and returns a Logger object based on the module name.
 func GetLogger(module string) (*Logger, error) {
-	return &Logger{Module: module}, nil
+	return &Logger{Module: module, calldepth: 2}, nil
 }
 
 // MustGetLogger is like GetLogger but panics if the logger can't be created.
@@ -156,11 +161,11 @@ func (l *Logger) log(lvl Level, format string, args ...interface{}) {
 	// calldepth=2 brings the stack up to the caller of the level
 	// methods, Info(), Fatal(), etc.
 	if l.haveBackend {
-		l.backend.Log(lvl, 2, record)
+		l.backend.Log(lvl, l.calldepth, record)
 		return
 	}
 
-	defaultBackend.Log(lvl, 2, record)
+	defaultBackend.Log(lvl, l.calldepth, record)
 }
 
 // Fatal is equivalent to l.Critical(fmt.Sprint()) followed by a call to os.Exit(1).


### PR DESCRIPTION
In case you want to wrap logger functions or export them in project's
package shortfunc in formatter is showing wrong function name.
This PR allows to set custom calldepth.
