### PR TITLE
Allow extra call depth to be configured for reflection

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -79,9 +79,10 @@ func (r *Record) Message() string {
 }
 
 type Logger struct {
-	Module      string
-	backend     LeveledBackend
-	haveBackend bool
+	Module         string
+	backend        LeveledBackend
+	haveBackend    bool
+	ExtraCalldepth int
 }
 
 func (l *Logger) SetBackend(backend LeveledBackend) {
@@ -156,11 +157,11 @@ func (l *Logger) log(lvl Level, format string, args ...interface{}) {
 	// calldepth=2 brings the stack up to the caller of the level
 	// methods, Info(), Fatal(), etc.
 	if l.haveBackend {
-		l.backend.Log(lvl, 2, record)
+		l.backend.Log(lvl, 2+l.ExtraCalldepth, record)
 		return
 	}
 
-	defaultBackend.Log(lvl, 2, record)
+	defaultBackend.Log(lvl, 2+l.ExtraCalldepth, record)
 }
 
 // Fatal is equivalent to l.Critical(fmt.Sprint()) followed by a call to os.Exit(1).


### PR DESCRIPTION
This allows logger methods to be exposed at the package level without breaking the function name logging. For example you can do:

```
var Debug = Logger.Debug
var Info = Logger.Info
```

and set ExtraCallDepth to 1 on the Logger, preventing the logging from recording things like "Debug·fm"
