### PR TITLE
Add opening bracket to GlogFormatter

### DIFF
--- a/format.go
+++ b/format.go
@@ -118,7 +118,7 @@ var (
 	DefaultFormatter Formatter = MustStringFormatter("%{message}")
 
 	// Glog format
-	GlogFormatter Formatter = MustStringFormatter("%{level:.1s}%{time:0102 15:04:05.999999} %{pid} %{shortfile}] %{message}")
+	GlogFormatter Formatter = MustStringFormatter("[%{level:.1s}%{time:0102 15:04:05.999999} %{pid} %{shortfile}] %{message}")
 )
 
 // SetFormatter sets the default formatter for all new backends. A backend will


### PR DESCRIPTION
I can't tell if this is intentional or not: https://github.com/op/go-logging/blob/master/format.go#L121

This produces output like:

```
I0321 19:49:55.5152 64259 music.go:75] Starting application
```

I think that the desired output is similar to the following with an opening bracket (which this PR adds):

```
[I0321 19:49:55.5152 64259 music.go:75] Starting application
```