### PR TITLE
Disable usless logflag

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -115,7 +115,7 @@ func Reset() {
 	// if there's no backends at all configured, we could use some tricks to
 	// automatically setup backends based if we have a TTY or not.
 	sequenceNo = 0
-	b := SetBackend(NewLogBackend(os.Stderr, "", log.LstdFlags))
+	b := SetBackend(NewLogBackend(os.Stderr, "", 0))
 	b.SetLevel(DEBUG, "")
 	SetFormatter(DefaultFormatter)
 	timeNow = time.Now


### PR DESCRIPTION
Using `log.LstdFlags` actually outputs `2006/01/02 03:04:05 ^M %{formated message}`, caused that systemd-journal treat it as binary blob because of `^M`.

Since date and time is used in string formatting, there's no need to put such flag.