### PR TITLE
Add logging functions with "f" suffix to avoid triggering go vet.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -210,6 +210,11 @@ func (l *Logger) Error(format string, args ...interface{}) {
 	l.log(ERROR, format, args...)
 }
 
+// Errorf logs a message using ERROR as log level.  It's identical to Error, but doesn't trigger go vet.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.log(ERROR, format, args...)
+}
+
 // Warning logs a message using WARNING as log level.
 func (l *Logger) Warning(format string, args ...interface{}) {
 	l.log(WARNING, format, args...)

--- a/logger.go
+++ b/logger.go
@@ -205,12 +205,17 @@ func (l *Logger) Critical(format string, args ...interface{}) {
 	l.log(CRITICAL, format, args...)
 }
 
+// Criticalf is identical to Critical, but doesn't trigger go vet.
+func (l *Logger) Criticalf(format string, args ...interface{}) {
+	l.log(CRITICAL, format, args...)
+}
+
 // Error logs a message using ERROR as log level.
 func (l *Logger) Error(format string, args ...interface{}) {
 	l.log(ERROR, format, args...)
 }
 
-// Errorf logs a message using ERROR as log level.  It's identical to Error, but doesn't trigger go vet.
+// Errorf is identical to Error, but doesn't trigger go vet.
 func (l *Logger) Errorf(format string, args ...interface{}) {
 	l.log(ERROR, format, args...)
 }
@@ -220,8 +225,18 @@ func (l *Logger) Warning(format string, args ...interface{}) {
 	l.log(WARNING, format, args...)
 }
 
+// Warningf is identical to Warning, but doesn't trigger go vet.
+func (l *Logger) Warningf(format string, args ...interface{}) {
+	l.log(WARNING, format, args...)
+}
+
 // Notice logs a message using NOTICE as log level.
 func (l *Logger) Notice(format string, args ...interface{}) {
+	l.log(NOTICE, format, args...)
+}
+
+// Noticef is identical to Notice, but doesn't trigger go vet.
+func (l *Logger) Noticef(format string, args ...interface{}) {
 	l.log(NOTICE, format, args...)
 }
 
@@ -230,8 +245,18 @@ func (l *Logger) Info(format string, args ...interface{}) {
 	l.log(INFO, format, args...)
 }
 
+// Infof is identical to Info, but doesn't trigger go vet.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.log(INFO, format, args...)
+}
+
 // Debug logs a message using DEBUG as log level.
 func (l *Logger) Debug(format string, args ...interface{}) {
+	l.log(DEBUG, format, args...)
+}
+
+// Debugf is identical to Debug, but doesn't trigger go vet.
+func (l *Logger) Debugf(format string, args ...interface{}) {
 	l.log(DEBUG, format, args...)
 }
 


### PR DESCRIPTION
Fixes https://github.com/op/go-logging/issues/29 while preserving backwards compatibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/op/go-logging/55)
<!-- Reviewable:end -->
