### PR TITLE
don't include memory backend on appengine

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -121,23 +121,6 @@ func Reset() {
 	timeNow = time.Now
 }
 
-// InitForTesting is a convenient method when using logging in a test. Once
-// called, the time will be frozen to January 1, 1970 UTC.
-func InitForTesting(level Level) *MemoryBackend {
-	Reset()
-
-	memoryBackend := NewMemoryBackend(10240)
-
-	leveledBackend := AddModuleLevel(memoryBackend)
-	leveledBackend.SetLevel(level, "")
-	SetBackend(leveledBackend)
-
-	timeNow = func() time.Time {
-		return time.Unix(0, 0).UTC()
-	}
-	return memoryBackend
-}
-
 // IsEnabledFor returns true if the logger is enabled for the given level.
 func (l *Logger) IsEnabledFor(level Level) bool {
 	return defaultBackend.IsEnabledFor(level, l.Module)

--- a/memory.go
+++ b/memory.go
@@ -9,10 +9,28 @@ package logging
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 )
 
 // TODO pick one of the memory backends and stick with it or share interface.
+
+// InitForTesting is a convenient method when using logging in a test. Once
+// called, the time will be frozen to January 1, 1970 UTC.
+func InitForTesting(level Level) *MemoryBackend {
+	Reset()
+
+	memoryBackend := NewMemoryBackend(10240)
+
+	leveledBackend := AddModuleLevel(memoryBackend)
+	leveledBackend.SetLevel(level, "")
+	SetBackend(leveledBackend)
+
+	timeNow = func() time.Time {
+		return time.Unix(0, 0).UTC()
+	}
+	return memoryBackend
+}
 
 // Node is a record node pointing to an optional next node.
 type node struct {

--- a/memory.go
+++ b/memory.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !appengine
+
 package logging
 
 import (


### PR DESCRIPTION
The google appengine doesn't allow import of the `unsafe` package and therefor the memory backend should be excluded from that target platform.

This should fix the following error when trying to deploy code to the appengine that imports `go-logging`:

```
go-app-builder: Failed parsing input: parser: bad import "unsafe" in github.com/op/go-logging/memory.go
```