### PR TITLE
Add syslog stub for windows to assist in cross platform builds.

### DIFF
--- a/syslog_fallback.go
+++ b/syslog_fallback.go
@@ -1,0 +1,28 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build windows plan9
+
+package logging
+
+import (
+	"fmt"
+)
+
+type Priority int
+
+type SyslogBackend struct {
+}
+
+func NewSyslogBackend(prefix string) (b *SyslogBackend, err error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}
+
+func NewSyslogBackendPriority(prefix string, priority Priority) (b *SyslogBackend, err error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}
+
+func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
+	return fmt.Errorf("Platform does not support syslog")
+}


### PR DESCRIPTION
Similar to PR #40 this allows builds to succeed on Windows, but returns an error if the syslog backend is instantiated instead of simply replacing it with a stdout logger. IMHO the behaviour of this PR is more correct and intuitive than of #40.

This is useful to allow cross-platform builds allowing the application itself to decide what to do when the syslog backend is unavailable.