### PR TITLE
cannot use err (type error) as type string in argument to log.Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Created by .ignore support plugin (hsz.mobi)

--- a/logger.go
+++ b/logger.go
@@ -195,8 +195,9 @@ func (l *Logger) Critical(format string, args ...interface{}) {
 }
 
 // Error logs a message using ERROR as log level.
-func (l *Logger) Error(format string, args ...interface{}) {
-	l.log(ERROR, format, args...)
+func (l *Logger) Error(args ...interface{}) {
+	s := fmt.Sprint(args...)
+	l.log(ERROR, "%s", s)
 }
 
 // Errorf logs a message using ERROR as log level.


### PR DESCRIPTION
```
if err != nil {
	log.Error(err)
}
```