### PR TITLE
Make Record.Args public so can be accessed by backends

### DIFF
--- a/format.go
+++ b/format.go
@@ -237,8 +237,8 @@ func NewStringFormatter(format string) (Formatter, error) {
 		Id:     12345,
 		Time:   t,
 		Module: "logger",
+		Args:   []interface{}{"go"},
 		fmt:    "hello %s",
-		args:   []interface{}{"go"},
 	}
 	if err := fmter.Format(0, r, &bytes.Buffer{}); err != nil {
 		return nil, err

--- a/logger.go
+++ b/logger.go
@@ -45,11 +45,11 @@ type Record struct {
 	Time   time.Time
 	Module string
 	Level  Level
+	Args   []interface{}
 
 	// message is kept as a pointer to have shallow copies update this once
 	// needed.
 	message   *string
-	args      []interface{}
 	fmt       string
 	formatter Formatter
 	formatted string
@@ -69,12 +69,12 @@ func (r *Record) Formatted(calldepth int) string {
 func (r *Record) Message() string {
 	if r.message == nil {
 		// Redact the arguments that implements the Redactor interface
-		for i, arg := range r.args {
+		for i, arg := range r.Args {
 			if redactor, ok := arg.(Redactor); ok == true {
-				r.args[i] = redactor.Redacted()
+				r.Args[i] = redactor.Redacted()
 			}
 		}
-		msg := fmt.Sprintf(r.fmt, r.args...)
+		msg := fmt.Sprintf(r.fmt, r.Args...)
 		r.message = &msg
 	}
 	return *r.message
@@ -144,7 +144,7 @@ func (l *Logger) log(lvl Level, format string, args ...interface{}) {
 		Module: l.Module,
 		Level:  lvl,
 		fmt:    format,
-		args:   args,
+		Args:   args,
 	}
 
 	// TODO use channels to fan out the records to all backends?


### PR DESCRIPTION
Hello, I'm creating a custom backend that logs errors to [sentry](https://getsentry.com). 

Sentry has a method to create a [StackTrace](https://godoc.org/github.com/getsentry/raven-go#Stacktrace) struct, which we do at the point the error is first created. We have a custom `error` type that we use to keep reference to it and then we log the error further up the stack. 

From within the custom backend, I'd like to be able to loop through `Record.Args` and see if any of the args are of this type so the stack can be passed to sentry. I accomplished this by simply making `Args` public, but if there is preferred way of doing, let me know.

Also, thanks for the great library! We have been using it for the past couple years.
