### PR TITLE
memoize formated messages in mem backends

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -22,7 +22,7 @@ func TestFormat(t *testing.T) {
 	log.Debug("hello")
 
 	line := MemoryRecordN(backend, 0).Formatted(0)
-	if "format_test.go:24 1970-01-01T00:00:00 D 0001 module hello" != line {
+	if "format_test.go:22 1970-01-01T00:00:00 D 0001 module hello" != line {
 		t.Errorf("Unexpected format: %s", line)
 	}
 }
@@ -37,13 +37,15 @@ func getLastLine(backend *MemoryBackend) string {
 }
 
 func realFunc(backend *MemoryBackend) string {
-	return logAndGetLine(backend)
+	MustGetLogger("foo").Debug("hello")
+	return getLastLine(backend)
 }
 
 type structFunc struct{}
 
 func (structFunc) Log(backend *MemoryBackend) string {
-	return logAndGetLine(backend)
+	MustGetLogger("foo").Debug("hello")
+	return getLastLine(backend)
 }
 
 func TestRealFuncFormat(t *testing.T) {

--- a/memory.go
+++ b/memory.go
@@ -61,6 +61,9 @@ func NewMemoryBackend(size int) *MemoryBackend {
 func (b *MemoryBackend) Log(level Level, calldepth int, rec *Record) error {
 	var size int32
 
+	// memoize the formated message so that stack information is preserved
+	rec.Formatted(calldepth + 1)
+
 	n := &node{Record: rec}
 	np := unsafe.Pointer(n)
 
@@ -223,6 +226,9 @@ func (b *ChannelMemoryBackend) Stop() {
 
 // Log implements the Log method required by Backend.
 func (b *ChannelMemoryBackend) Log(level Level, calldepth int, rec *Record) error {
+	// memoize the formated message so that stack information is preserved
+	rec.Formatted(calldepth + 1)
+
 	b.incoming <- rec
 	return nil
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -58,6 +58,9 @@ func TestMemoryBackend(t *testing.T) {
 		t.Errorf("record length: %d", backend.size)
 	}
 	record := MemoryRecordN(backend, 0)
+	if record.formatted == "" {
+		t.Error("record was not preformated")
+	}
 	if "5" != record.Formatted(0) {
 		t.Errorf("unexpected start: %s", record.Formatted(0))
 	}
@@ -97,6 +100,9 @@ func TestChannelMemoryBackend(t *testing.T) {
 		t.Errorf("record length: %d", backend.size)
 	}
 	record := ChannelMemoryRecordN(backend, 0)
+	if record.formatted == "" {
+		t.Error("record was not preformated")
+	}
 	if "5" != record.Formatted(0) {
 		t.Errorf("unexpected start: %s", record.Formatted(0))
 	}


### PR DESCRIPTION
fix longfunc/shortfunc line number test cases

Addresses https://github.com/op/go-logging/issues/90