### PR TITLE
[Backend][Reentrant] Introduce Reentrant Backend

### DIFF
--- a/log_test.go
+++ b/log_test.go
@@ -9,8 +9,13 @@ import (
 	"io/ioutil"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 )
+
+type syncTestConcurrent struct {
+	start, end sync.WaitGroup
+}
 
 func TestLogCalldepth(t *testing.T) {
 	buf := &bytes.Buffer{}

--- a/memory.go
+++ b/memory.go
@@ -68,21 +68,17 @@ func (b *MemoryBackend) Log(level Level, calldepth int, rec *Record) error {
 	// head will both be nil. When we successfully set the tail and the previous
 	// value was nil, it's safe to set the head to the current value too.
 	for {
-		tailp := b.tail
-		swapped := atomic.CompareAndSwapPointer(
+		tailp := atomic.SwapPointer(
 			&b.tail,
-			tailp,
 			np,
 		)
-		if swapped == true {
-			if tailp == nil {
-				b.head = np
-			} else {
-				(*node)(tailp).next = n
-			}
-			size = atomic.AddInt32(&b.size, 1)
-			break
+		if tailp == nil {
+			b.head = np
+		} else {
+			(*node)(tailp).next = n
 		}
+		size = atomic.AddInt32(&b.size, 1)
+		break
 	}
 
 	// Since one record was added, we might have overflowed the list. Remove


### PR DESCRIPTION
Level and memory backend are read mostly, so atomic value can a very
limited effect on performance; Only write map acces need to be done under
Mutex.

Now Backend loggers could be called from multiple goroutine.

Tests validated with : go test -v -race ./...
