### PR TITLE
Added SetTimeNow function to override global timeNow func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.test
+.idea
+*.iml
+*~

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ func main() {
 
 	// Set the backends to be used.
 	logging.SetBackend(backend1Leveled, backend2Formatter)
+	
+	// Set log time to UTC, default is Local
+	logging.SetTimeNow(time.Now().UTC)
 
 	log.Debugf("debug %s", Password("secret"))
 	log.Info("info")

--- a/logger.go
+++ b/logger.go
@@ -123,6 +123,11 @@ func MustGetLogger(module string) *Logger {
 	return logger
 }
 
+// SetTimeNow configures the time.Time value generated for log time values
+func SetTimeNow(now func () time.Time) {
+	timeNow = now
+}
+
 // Reset restores the internal state of the logging library.
 func Reset() {
 	// TODO make a global Init() method to be less magic? or make it such that

--- a/logger_test.go
+++ b/logger_test.go
@@ -4,7 +4,10 @@
 
 package logging
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 type Password string
 
@@ -58,5 +61,22 @@ func TestPrivateBackend(t *testing.T) {
 	}
 	if "to private baсkend" == MemoryRecordN(privateBackend, 0).Formatted(0) {
 		t.Error("logged to defaultBackend:", MemoryRecordN(privateBackend, 0))
+	}
+}
+
+func TestLogger_SetTimerNow(t *testing.T) {
+	_ = InitForTesting(DEBUG)
+	_ = MustGetLogger("test")
+
+	if now := timeNow(); now != time.Unix(0, 0).UTC() {
+		t.Error("test timeNow incorrect", now)
+	}
+
+	SetTimeNow(func() time.Time {
+		return time.Unix(1, 1)
+	})
+
+	if now := timeNow(); now != time.Unix(1, 1) {
+		t.Error("test timeNow dit not get overwritten", now)
 	}
 }


### PR DESCRIPTION
Looking at `logger.go`, seems we default to Local time. Make sense for some, but it would be nice to be able to correlate logs with UTC time based events.

```
var (
    // Sequence number is incremented and utilized for all log records created.
    sequenceNo uint64

    // timeNow is a customizable for testing purposes.
    timeNow = time.Now
)
```

This PR adds and exposes a `SetTimeNow(func() time.Time)` function to provide the end user a choice whether to log using the default Local time, or UTC, or MST, etc. 

```
func init() {
    backend1 := logging.NewLogBackend(os.Stderr, "", 0)
    backend1Leveled := logging.AddModuleLevel(backend1)

    // Log UTC time, default is Local
    logging.SetTimeNow(time.Now().UTC)

    logging.SetBackend(backend1Leveled)
}
```
