### PR TITLE
Cleaning up error from gofmt and complaints from linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ package main
 import (
 	"os"
 
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("example")
@@ -40,6 +40,7 @@ var format = logging.MustStringFormatter(
 // time this is logged, the Redacted() function will be called.
 type Password string
 
+// Redacted returns a redacted string, used here to mask passwords as an example.
 func (p Password) Redacted() interface{} {
 	return logging.Redact(string(p))
 }

--- a/examples/example.go
+++ b/examples/example.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("example")
@@ -19,6 +19,7 @@ var format = logging.MustStringFormatter(
 // time this is logged, the Redacted() function will be called.
 type Password string
 
+// Redacted returns a redacted string, used here to mask passwords as an example.
 func (p Password) Redacted() interface{} {
 	return logging.Redact(string(p))
 }


### PR DESCRIPTION
Cleaning up come complaints from the linter, and added a named import for logger since gofmt doesn't recognize it and automatically removes it.