### PR TITLE
Make the time generating function settable from the outside

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -33,8 +33,9 @@ var (
 	// Sequence number is incremented and utilized for all log records created.
 	sequenceNo uint64
 
-	// timeNow is a customizable for testing purposes.
-	timeNow = time.Now
+	// TimeNow is is made public to allow to be set external.
+	TimeNow = time.Now
+
 )
 
 // Record represents a log record and contains the timestamp when the record
@@ -132,7 +133,7 @@ func Reset() {
 	b := SetBackend(NewLogBackend(os.Stderr, "", log.LstdFlags))
 	b.SetLevel(DEBUG, "")
 	SetFormatter(DefaultFormatter)
-	timeNow = time.Now
+	TimeNow = time.Now
 }
 
 // IsEnabledFor returns true if the logger is enabled for the given level.
@@ -148,7 +149,7 @@ func (l *Logger) log(lvl Level, format *string, args ...interface{}) {
 	// Create the logging record and pass it in to the backend
 	record := &Record{
 		ID:     atomic.AddUint64(&sequenceNo, 1),
-		Time:   timeNow(),
+		Time:   TimeNow(),
 		Module: l.Module,
 		Level:  lvl,
 		fmt:    format,

--- a/memory.go
+++ b/memory.go
@@ -26,7 +26,7 @@ func InitForTesting(level Level) *MemoryBackend {
 	leveledBackend.SetLevel(level, "")
 	SetBackend(leveledBackend)
 
-	timeNow = func() time.Time {
+	TimeNow = func() time.Time {
 		return time.Unix(0, 0).UTC()
 	}
 	return memoryBackend


### PR DESCRIPTION
Export timeNow to make the time-generating function settable from the outside (see #98).