### PR TITLE
Support for %{env} variable in formatter.

### DIFF
--- a/format.go
+++ b/format.go
@@ -311,7 +311,7 @@ func (f *stringFormatter) Format(calldepth int, r *Record, output io.Writer) err
 				v = r.Message()
 				break
 			case fmtVerbEnv:
-				v = os.Getenv("TMC_ENV")
+				v = os.Getenv("ENV")
 			case fmtVerbLongfile, fmtVerbShortfile:
 				_, file, line, ok := runtime.Caller(calldepth + 1)
 				if !ok {

--- a/format.go
+++ b/format.go
@@ -42,6 +42,7 @@ const (
 	fmtVerbShortfunc
 	fmtVerbCallpath
 	fmtVerbLevelColor
+	fmtVerbEnv
 
 	// Keep last, there are no match for these below.
 	fmtVerbUnknown
@@ -64,6 +65,7 @@ var fmtVerbs = []string{
 	"shortfunc",
 	"callpath",
 	"color",
+	"env",
 }
 
 const rfc3339Milli = "2006-01-02T15:04:05.999Z07:00"
@@ -84,6 +86,7 @@ var defaultVerbsLayout = []string{
 	"s",
 	"0",
 	"",
+	"s",
 }
 
 var (
@@ -154,6 +157,7 @@ type stringFormatter struct {
 // The verbs:
 //
 // General:
+//     %{env}       Environment
 //     %{id}        Sequence number for log message (uint64).
 //     %{pid}       Process id (int)
 //     %{time}      Time when log occurred (time.Time)
@@ -306,6 +310,8 @@ func (f *stringFormatter) Format(calldepth int, r *Record, output io.Writer) err
 			case fmtVerbMessage:
 				v = r.Message()
 				break
+			case fmtVerbEnv:
+				v = os.Getenv("TMC_ENV")
 			case fmtVerbLongfile, fmtVerbShortfile:
 				_, file, line, ok := runtime.Caller(calldepth + 1)
 				if !ok {


### PR DESCRIPTION
Greetings,

Would be great to support %{env} variable in formatter that can be `staging`, `dev`, `prod`, etc.

I made it taken from `os.Getenv("ENV")` but open for other suggestions.

Cheers
Eugene