### PR TITLE
Fix https://github.com/op/go-logging/issues/125

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -137,6 +137,9 @@ func Reset() {
 
 // IsEnabledFor returns true if the logger is enabled for the given level.
 func (l *Logger) IsEnabledFor(level Level) bool {
+	if l.haveBackend {
+		return l.backend.IsEnabledFor(level, l.Module)
+	}
 	return defaultBackend.IsEnabledFor(level, l.Module)
 }
 


### PR DESCRIPTION
 * Update `Logger` struct to use private `backend` instead of
   the package `defaultBackend`, if `haveBackend` is `false`
   the `defaultBackend` will be used as a fallback.