### PR TITLE
go-logging: provide right pc to runtime.FuncForPC

### DIFF
--- a/format.go
+++ b/format.go
@@ -385,7 +385,7 @@ func formatCallpath(calldepth int, depth int) string {
 		if i < start {
 			v += "."
 		}
-		if f := runtime.FuncForPC(pc); f != nil {
+		if f := runtime.FuncForPC(pc - 1); f != nil {
 			v += formatFuncName(fmtVerbShortfunc, f.Name())
 		}
 	}


### PR DESCRIPTION
We want a PC in the call instruction, not the PC of the instruction
just after the call instruction.

(A more robust fix would be to move to runtime.CallersFrames, as
runtime.Callers+runtime.FuncForPC is deprecated.)

This updates go-logging so it works with the mid-stack inlining coming
with go 1.12.